### PR TITLE
Fix for the case that  "./" is not in $PATH

### DIFF
--- a/bpcviz.plot
+++ b/bpcviz.plot
@@ -14,7 +14,7 @@
   delim: comma
   // -d <days to view> -s <time|host> -p <hostdir path> -e <exclude regex>
   // defaults: -d 3 -s time -p /usr/lib/backuppc/pc
-  command: ./bpcviz-gatherdata
+  command: bpcviz-gatherdata
 
 // the legendentrys match a color (details) to
 // the field value (incr/full) in the data file,


### PR DESCRIPTION
just added a ./ to bpviz.plot so that the command line looks like:
  command: ./bpcviz-gatherdata

this is mainly usefull for systems where the local directory is not in $PATH and solves the error that the command bpcviz-gatherdata is not found
